### PR TITLE
Fix circuit breaker description formatting in API README

### DIFF
--- a/src/api/README.md
+++ b/src/api/README.md
@@ -1,6 +1,6 @@
 # Kraken REST API Client
 
-Comprehensive async REST API client for Kraken with full integration support including authentication, rate limiting, circuit breaker protection, and comprehensive error handling.
+Comprehensive async REST API client for Kraken with full integration support. Includes authentication, rate limiting, circuit breaker protection, and comprehensive error handling.
 
 ## Features
 


### PR DESCRIPTION
## Summary
- reworded the API README introduction to keep the circuit breaker phrase intact without mid-word breaking

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922a7348f8c8333b01aae4cfa027c54)