### PR TITLE
Add configuration scaffolding and basic tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,13 +1,9 @@
 [pytest]
 minversion = 6.0
-addopts = 
-    -ra 
-    -q 
-    --strict-markers 
-    --cov=src 
-    --cov-report=html 
-    --cov-report=term-missing
-    --cov-report=xml
+addopts =
+    -ra
+    -q
+    --strict-markers
     --maxfail=1
     --tb=short
     --disable-warnings

--- a/src/config/learning.py
+++ b/src/config/learning.py
@@ -1,0 +1,26 @@
+"""Learning configuration manager."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class LearningConfigManager:
+    """Handle adaptive learning and model tuning configuration."""
+
+    def __init__(self, core_config: dict[str, Any]):
+        self.core_config = core_config
+        self.learning_config = self._build_learning_config()
+
+    def _build_learning_config(self) -> dict[str, Any]:
+        return {
+            "adaptive_enabled": True,
+            "lookback_window": 100,
+            "confidence_threshold": 0.6,
+            "max_models": 3,
+            "data_directory": self.core_config.get("data_directory", "D:/trading_bot_data"),
+        }
+
+    def get_all_settings(self) -> dict[str, Any]:
+        """Return the learning configuration dictionary."""
+        return self.learning_config

--- a/src/config/risk.py
+++ b/src/config/risk.py
@@ -1,0 +1,25 @@
+"""Risk configuration manager."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class RiskConfigManager:
+    """Manage risk-related parameters such as limits and buffers."""
+
+    def __init__(self, core_config: dict[str, Any]):
+        self.core_config = core_config
+        self.risk_config = self._build_risk_config()
+
+    def _build_risk_config(self) -> dict[str, Any]:
+        return {
+            "max_daily_loss": float(self.core_config.get("max_daily_loss", 50.0)),
+            "min_order_size_usdt": float(self.core_config.get("min_order_size_usdt", 1.0)),
+            "circuit_breaker_threshold": 0.02,
+            "cooldown_minutes": 5,
+        }
+
+    def get_all_settings(self) -> dict[str, Any]:
+        """Return the risk configuration dictionary."""
+        return self.risk_config

--- a/src/config/trading.py
+++ b/src/config/trading.py
@@ -1,0 +1,31 @@
+"""Trading configuration manager."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class TradingConfigManager:
+    """Manage trading parameters derived from the core configuration."""
+
+    def __init__(self, core_config: dict[str, Any]):
+        self.core_config = core_config
+        self.trading_config = self._build_trading_config()
+
+    def _build_trading_config(self) -> dict[str, Any]:
+        base_pairs = self.core_config.get("trading_pairs", [])
+        position_size = float(self.core_config.get("position_size_usdt", 2.0))
+        max_position_pct = float(self.core_config.get("max_position_pct", 0.8))
+
+        return {
+            "trading_pairs": base_pairs,
+            "position_size_usdt": position_size,
+            "max_position_pct": max_position_pct,
+            "take_profit_percent": 0.002,
+            "stop_loss_percent": 0.005,
+            "use_fee_free": self.core_config.get("environment", "production") != "sandbox",
+        }
+
+    def get_all_settings(self) -> dict[str, Any]:
+        """Return the trading configuration dictionary."""
+        return self.trading_config

--- a/src/config/validator.py
+++ b/src/config/validator.py
@@ -1,0 +1,44 @@
+"""Configuration validator with simple sanity checks."""
+
+from __future__ import annotations
+
+from typing import Any, Tuple
+
+
+class ConfigValidator:
+    """Validate composed configuration sections and propose fixes."""
+
+    def validate_config(self, config: dict[str, Any]) -> Tuple[bool, list[str], list[str]]:
+        errors: list[str] = []
+        fixes: list[str] = []
+
+        core = config.get("core", {})
+        trading = config.get("trading", {})
+        risk = config.get("risk", {})
+        kraken = config.get("kraken", {})
+
+        if not core.get("trading_pairs"):
+            fixes.append("Added default trading pairs")
+            trading_pairs = ["BTC/USDT", "ETH/USDT"]
+            core = {**core, "trading_pairs": trading_pairs}
+
+        if risk.get("max_daily_loss", 0) <= 0:
+            errors.append("max_daily_loss must be positive")
+
+        if trading.get("position_size_usdt", 0) <= 0:
+            errors.append("position_size_usdt must be positive")
+
+        if kraken.get("rate_limit_calls_per_second", 1) <= 0:
+            fixes.append("Reset Kraken rate limit to default")
+            kraken = {**kraken, "rate_limit_calls_per_second": 1}
+
+        is_valid = not errors
+        updated_config = {
+            "core": core,
+            "trading": trading,
+            "risk": risk,
+            "kraken": kraken,
+            "learning": config.get("learning", {}),
+        }
+        config.update(updated_config)
+        return is_valid, errors, fixes

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,35 @@
+from src.config.config import Config
+
+
+def test_config_env_fallback(monkeypatch):
+    monkeypatch.delenv("KRAKEN_API_KEY", raising=False)
+    monkeypatch.delenv("KRAKEN_API_SECRET", raising=False)
+
+    cfg = Config(api_key="explicit-key", api_secret="explicit-secret")
+
+    assert cfg.api_key == "explicit-key"
+    assert cfg.api_secret == "explicit-secret"
+
+    monkeypatch.setenv("KRAKEN_API_KEY", "env-key")
+    monkeypatch.setenv("KRAKEN_API_SECRET", "env-secret")
+
+    cfg_env = Config()
+    assert cfg_env.api_key == "env-key"
+    assert cfg_env.api_secret == "env-secret"
+
+
+def test_config_validation_rules():
+    cfg = Config()
+    assert cfg.validate() is True
+
+    cfg_invalid = Config(rsi_oversold=60, rsi_overbought=40)
+    assert cfg_invalid.validate() is False
+
+
+def test_config_to_dict_roundtrip():
+    cfg = Config(trading_pairs=["BTC/USD"], max_open_positions=10)
+    cfg_dict = cfg.to_dict()
+
+    recreated = Config.from_dict(cfg_dict)
+    assert recreated.trading_pairs == ["BTC/USD"]
+    assert recreated.max_open_positions == 10


### PR DESCRIPTION
## Summary
- add missing configuration manager modules for trading, risk, learning, and validation
- simplify pytest defaults for environments without coverage plugins
- add unit tests for configuration serialization and validation

## Testing
- pytest -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c3a07e2e08333b2da252101eadbfe)