### PR TITLE
Convert buy test to mocked unit test

### DIFF
--- a/test_buy.py
+++ b/test_buy.py
@@ -1,42 +1,81 @@
-#!/usr/bin/env python3
 """
-TEST BUY SMALL BTC
+Unit tests for safe BTC buying logic using a mocked ccxt client.
 """
 
-import os
+from unittest.mock import MagicMock
 
 import ccxt
-from dotenv import load_dotenv
+import pytest
 
-load_dotenv()
 
-exchange = ccxt.kraken({
-    'apiKey': os.getenv('KRAKEN_KEY'),
-    'secret': os.getenv('KRAKEN_SECRET'),
-    'enableRateLimit': True
-})
+BUY_AMOUNT_USD = 20
+PAIR = "BTC/USDT"
 
-# Check balance
-balance = exchange.fetch_balance()
-usdt = balance.get('USDT', {}).get('free', 0)
-print(f"USDT Balance: ${usdt:.2f}")
 
-# Get BTC price
-ticker = exchange.fetch_ticker('BTC/USDT')
-print(f"BTC Price: ${ticker['last']:,.2f}")
+def place_small_btc_order(exchange):
+    """
+    Execute the small BTC buy flow using the provided exchange client.
 
-# Calculate tiny amount
-btc_amount = 20 / ticker['last']  # $20 worth
-btc_amount = round(btc_amount, 6)
-print(f"Will buy: {btc_amount:.6f} BTC (~$20)")
+    The exchange client must provide ``fetch_balance``, ``fetch_ticker``, and
+    ``create_market_buy_order`` methods. No real network calls are made because
+    the caller is expected to pass a mock.
+    """
 
-if usdt >= 20:
-    print("\nPlacing order...")
-    try:
-        order = exchange.create_market_buy_order('BTC/USDT', btc_amount)
-        print(f"✅ SUCCESS! Order ID: {order['id']}")
-        print(f"Bought {btc_amount:.6f} BTC")
-    except Exception as e:
-        print(f"❌ Error: {e}")
-else:
-    print("❌ Not enough USDT")
+    balance = exchange.fetch_balance()
+    usdt_available = balance.get("USDT", {}).get("free", 0)
+
+    ticker = exchange.fetch_ticker(PAIR)
+    btc_amount = round(BUY_AMOUNT_USD / ticker["last"], 6)
+
+    if usdt_available >= BUY_AMOUNT_USD:
+        return exchange.create_market_buy_order(PAIR, btc_amount)
+
+    return None
+
+
+def test_buy_places_order_with_sufficient_balance(monkeypatch):
+    """Ensure the buy logic uses the mocked exchange and places the order."""
+
+    # Explicitly prevent accidental instantiation of a real client.
+    monkeypatch.setattr(
+        ccxt,
+        "kraken",
+        lambda *_, **__: pytest.fail("Real ccxt client must not be used"),
+    )
+
+    mock_exchange = MagicMock()
+    mock_exchange.fetch_balance.return_value = {"USDT": {"free": 25}}
+    mock_exchange.fetch_ticker.return_value = {"last": 40_000}
+    mock_exchange.create_market_buy_order.return_value = {"id": "mock-order"}
+
+    order = place_small_btc_order(mock_exchange)
+
+    expected_amount = round(BUY_AMOUNT_USD / 40_000, 6)
+    mock_exchange.fetch_balance.assert_called_once_with()
+    mock_exchange.fetch_ticker.assert_called_once_with(PAIR)
+    mock_exchange.create_market_buy_order.assert_called_once_with(
+        PAIR, pytest.approx(expected_amount)
+    )
+    assert order == {"id": "mock-order"}
+
+
+def test_buy_skips_order_with_insufficient_balance(monkeypatch):
+    """Verify no order is placed when the USDT balance is too low."""
+
+    # Explicitly prevent accidental instantiation of a real client.
+    monkeypatch.setattr(
+        ccxt,
+        "kraken",
+        lambda *_, **__: pytest.fail("Real ccxt client must not be used"),
+    )
+
+    mock_exchange = MagicMock()
+    mock_exchange.fetch_balance.return_value = {"USDT": {"free": 5}}
+    mock_exchange.fetch_ticker.return_value = {"last": 30_000}
+
+    order = place_small_btc_order(mock_exchange)
+
+    mock_exchange.fetch_balance.assert_called_once_with()
+    mock_exchange.fetch_ticker.assert_called_once_with(PAIR)
+    mock_exchange.create_market_buy_order.assert_not_called()
+    assert order is None


### PR DESCRIPTION
## Summary
- replace the ad-hoc buy script with assert-based unit tests using pytest
- mock the ccxt client to ensure no live network calls occur during tests

## Testing
- pytest --override-ini addopts= --override-ini filterwarnings=default --override-ini asyncio_mode=auto test_buy.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922b6a81ce88333942bad7c444216f8)